### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#portaudio
+# portaudio
 
 This package provides an interface to the [PortAudio](http://www.portaudio.com/) audio I/O library.  See the [package documentation](http://godoc.org/github.com/gordonklaus/portaudio) for details.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
