### PR TITLE
Changed initialized counter to atomic and moved initialize to a separate file

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,12 @@
+/*
+Package portaudio applies Go bindings to the PortAudio library.
+
+For the most part, these bindings parallel the underlying PortAudio API; please refer to http://www.portaudio.com/docs.html for details.  Differences introduced by the bindings are documented here:
+
+Instead of passing a flag to OpenStream, audio sample formats are inferred from the signature of the stream callback or, for a blocking stream, from the types of the buffers.  See the StreamCallback and Buffer types for details.
+
+Blocking I/O:  Read and Write do not accept buffer arguments; instead they use the buffers (or pointers to buffers) provided to OpenStream.  The number of samples to read or write is determined by the size of the buffers.
+
+The StreamParameters struct combines parameters for both the input and the output device as well as the sample rate, buffer size, and flags.
+*/
+package portaudio

--- a/initialize.go
+++ b/initialize.go
@@ -1,0 +1,65 @@
+package portaudio
+
+/*
+#cgo pkg-config: portaudio-2.0
+#include <portaudio.h>
+extern PaStreamCallback* paStreamCallback;
+*/
+import "C"
+
+import (
+	"sync/atomic"
+)
+
+// A simple counter about how many times port audio was
+// initialized
+var initialized = new(int32)
+
+// Initialize initializes internal data structures and
+// prepares underlying host APIs for use. With the exception
+// of Version(), VersionText(), and ErrorText(), this function
+// MUST be called before using any other PortAudio API functions.
+//
+// If Initialize() is called multiple times, each successful call
+// must be matched with a corresponding call to Terminate(). Pairs of
+// calls to Initialize()/Terminate() may overlap, and are not required to be fully nested.
+//
+// Note that if Initialize() returns an error code, Terminate() should NOT be called.
+func Initialize() error {
+	paErr := C.Pa_Initialize()
+	if paErr != C.paNoError {
+		return newError(paErr)
+	}
+	atomic.AddInt32(initialized, 1)
+	return nil
+}
+
+// Terminate deallocates all resources allocated by PortAudio
+// since it was initialized by a call to Initialize().
+//
+// In cases where Initialize() has been called multiple times,
+// each call must be matched with a corresponding call to Pa_Terminate().
+// The final matching call to Pa_Terminate() will automatically
+// close any PortAudio streams that are still open..
+//
+// Terminate MUST be called before exiting a program which uses PortAudio.
+// Failure to do so may result in serious resource leaks, such as audio devices
+// not being available until the next reboot.
+func Terminate() error {
+	paErr := C.Pa_Terminate()
+	if paErr != C.paNoError {
+		return newError(paErr)
+	}
+
+	set := atomic.AddInt32(initialized, -1)
+	if set <= 0 {
+		atomic.StoreInt32(initialized, 0)
+		cached = false
+	}
+	return nil
+}
+
+// Returns whether or not port audio has already been initialized
+func isInitialized() bool {
+	return atomic.LoadInt32(initialized) > 0
+}


### PR DESCRIPTION
Moved initialization related functions to a separate file and encapsulated a way to check to see if port audio was initialized

Motivation for this is because the variable was intertwined in multiple functions, and it was not safe for concurrent usage.

Moving it to a separate file separates it so it's easier for future development.