### PR TITLE
Fix checkptr issue in setChannels.

### DIFF
--- a/portaudio.go
+++ b/portaudio.go
@@ -894,10 +894,9 @@ func updateBuffer(buf *reflect.SliceHeader, p uintptr, params *C.PaStreamParamet
 }
 
 func setChannels(s *reflect.SliceHeader, p uintptr, frames int) {
-	sp := s.Data
 	for i := 0; i < s.Len; i++ {
-		setSlice((*reflect.SliceHeader)(unsafe.Pointer(sp)), *(*uintptr)(unsafe.Pointer(p)), frames)
-		sp += unsafe.Sizeof(reflect.SliceHeader{})
+		buf := unsafe.Pointer(uintptr(unsafe.Pointer(s.Data)) + unsafe.Sizeof(reflect.SliceHeader{})*uintptr(i))
+		setSlice((*reflect.SliceHeader)(buf), *(*uintptr)(unsafe.Pointer(p)), frames)
 		p += unsafe.Sizeof(uintptr(0))
 	}
 }


### PR DESCRIPTION
The `checkptr` instrumentation added in Go 1.14 (https://golang.org/doc/go1.14#compiler) was causing a panic for me in the portaudio package, when building with `-race`. See the stack trace below. If I'm reading the unsafe.Pointer rules correctly, it seems the issue is with storing the uintptr in a variable, as opposed to doing the arithmetic inline and immediately converting back to an unsafe.Pointer, as I've done in the patch.

```
fatal error: checkptr: unsafe pointer arithmetic

goroutine 17 [running, locked to thread]:
runtime.throw(0x421f30e, 0x23)
	/usr/local/Cellar/go/1.14/libexec/src/runtime/panic.go:1112 +0x72 fp=0xc000042c80 sp=0xc000042c50 pc=0x40342f2
runtime.checkptrArithmetic(0xc00009d7a0, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.14/libexec/src/runtime/checkptr.go:41 +0xb5 fp=0xc000042cb0 sp=0xc000042c80 pc=0x4008d15
github.com/gordonklaus/portaudio.setChannels(0xc0000aa1e0, 0x50104a0, 0x200)
	/Users/menno/gohack/github.com/gordonklaus/portaudio/portaudio.go:906 +0xfa fp=0xc000042d08 sp=0xc000042cb0 pc=0x4158fda
github.com/gordonklaus/portaudio.updateBuffer(0xc0000aa1e0, 0x50104a0, 0xc0000aa220, 0x200)
	/Users/menno/gohack/github.com/gordonklaus/portaudio/portaudio.go:899 +0x137 fp=0xc000042d40 sp=0xc000042d08 pc=0x4158eb7
github.com/gordonklaus/portaudio.streamCallback(0x0, 0x50104a0, 0x200, 0x70000afd8a00, 0x0, 0x0)
	/Users/menno/gohack/github.com/gordonklaus/portaudio/portaudio.go:881 +0x26a fp=0xc000042e30 sp=0xc000042d40 pc=0x4158c9a
github.com/gordonklaus/portaudio._cgoexpwrap_d0a369011808_streamCallback(0x0, 0x50104a0, 0x200, 0x70000afd8a00, 0x0, 0x0)
	_cgo_gotypes.go:593 +0x6b fp=0xc000042e70 sp=0xc000042e30 pc=0x415461b
runtime.call64(0x0, 0x70000afd8760, 0x70000afd87f8, 0x30)
	/usr/local/Cellar/go/1.14/libexec/src/runtime/asm_amd64.s:540 +0x3b fp=0xc000042ec0 sp=0xc000042e70 pc=0x406334b
runtime.cgocallbackg1(0x0)
	/usr/local/Cellar/go/1.14/libexec/src/runtime/cgocall.go:332 +0x1ac fp=0xc000042f58 sp=0xc000042ec0 pc=0x400561c
runtime.cgocallbackg(0x0)
	/usr/local/Cellar/go/1.14/libexec/src/runtime/cgocall.go:207 +0xc1 fp=0xc000042fc0 sp=0xc000042f58 pc=0x40053d1
runtime.cgocallback_gofunc(0x0, 0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.14/libexec/src/runtime/asm_amd64.s:793 +0x9b fp=0xc000042fe0 sp=0xc000042fc0 pc=0x406489b
runtime.goexit()
	/usr/local/Cellar/go/1.14/libexec/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc000042fe8 sp=0xc000042fe0 pc=0x4065001
```
