### PR TITLE
Expose device index

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/gordonklaus/portaudio
 
 go 1.18
-
-require github.com/bobertlo/go-mpg123 v0.0.0-20211210004329-c83f21a0fd39

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/gordonklaus/portaudio
 
 go 1.18
+
+require github.com/bobertlo/go-mpg123 v0.0.0-20211210004329-c83f21a0fd39

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/bobertlo/go-mpg123 v0.0.0-20211210004329-c83f21a0fd39 h1:VCejVrz3ZyFZbDZTAawyzqVTPvsqaYkDNriuvqI+Ul4=
+github.com/bobertlo/go-mpg123 v0.0.0-20211210004329-c83f21a0fd39/go.mod h1:mXbpHtCUpJj6n++mw/GWIxTeajLCSA7+uKHc9yP+WBI=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/bobertlo/go-mpg123 v0.0.0-20211210004329-c83f21a0fd39 h1:VCejVrz3ZyFZbDZTAawyzqVTPvsqaYkDNriuvqI+Ul4=
-github.com/bobertlo/go-mpg123 v0.0.0-20211210004329-c83f21a0fd39/go.mod h1:mXbpHtCUpJj6n++mw/GWIxTeajLCSA7+uKHc9yP+WBI=

--- a/portaudio.go
+++ b/portaudio.go
@@ -209,7 +209,7 @@ type HostApiInfo struct {
 
 // DeviceInfo contains information for an audio device.
 type DeviceInfo struct {
-	index                    C.PaDeviceIndex
+	Index                    int
 	Name                     string
 	MaxInputChannels         int
 	MaxOutputChannels        int
@@ -333,7 +333,7 @@ func hostsAndDevices() ([]*HostApiInfo, []*DeviceInfo, error) {
 			i := C.PaDeviceIndex(i)
 			paDev := C.Pa_GetDeviceInfo(i)
 			devices[i] = &DeviceInfo{
-				index:                    i,
+				Index:                    int(i),
 				Name:                     C.GoString(paDev.name),
 				MaxInputChannels:         int(paDev.maxInputChannels),
 				MaxOutputChannels:        int(paDev.maxOutputChannels),
@@ -851,7 +851,7 @@ func sampleFormat(b reflect.Type) (f C.PaSampleFormat) {
 
 func paStreamParameters(p StreamDeviceParameters, fmt C.PaSampleFormat) *C.PaStreamParameters {
 	return &C.PaStreamParameters{
-		device:           p.Device.index,
+		device:           C.int(p.Device.Index),
 		channelCount:     C.int(p.Channels),
 		sampleFormat:     fmt,
 		suggestedLatency: C.PaTime(p.Latency.Seconds()),


### PR DESCRIPTION
In cases where there are multiple devices with the same name, it can be extremely difficult to cross reference which is being referred to in a dropdown menu for example. By exposing the device index, we now have a unqiue key which can be used for reliable selection.